### PR TITLE
Add google site verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,9 @@
-## Welcome to GitHub Pages
+# how to run-up this page in local
 
-You can use the [editor on GitHub](https://github.com/andy840119/andy840119.github.io/edit/master/README.md) to maintain and preview the content for your website in Markdown files.
-
-Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
-
-### Markdown
-
-Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
-
-```markdown
-Syntax highlighted code block
-
-# Header 1
-## Header 2
-### Header 3
-
-- Bulleted
-- List
-
-1. Numbered
-2. List
-
-**Bold** and _Italic_ and `Code` text
-
-[Link](url) and ![Image](src)
-```
-
-For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
-
-### Jekyll Themes
-
-Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/andy840119/andy840119.github.io/settings). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
-
-### Support or Contact
-
-Having trouble with Pages? Check out our [documentation](https://help.github.com/categories/github-pages-basics/) or [contact support](https://github.com/contact) and we’ll help you sort it out.
+1. Got a mac
+2. git clone `https://github.com/golangProjectCrusaders/golangProjectCrusaders.github.io.git`
+3. open terminal then run `gem install --user-install bundler jekyll`
+4. cd `golangProjectCrusaders.github.io`
+5. run `bundle install`(restore package)
+6. run `bundle exec jekyll serve`
+7. `http://localhost:4000/` then got your page.

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,12 @@ aux_links:
 # navigation
 facebook_url: https://www.facebook.com/OAQaa
 
-# trackng
+# google seo verification
+# https://search.google.com/search-console/welcome
+# https://github.com/jekyll/jekyll/issues/3514
+google_verify: nhKskbQxAPbq7OADIwe5KmhVGs5liv0pfe2hHTQTfFU=
+
+# tracking
 google_analytics: UA-164533327-1
 
 # Footer content appears at the bottom of every page's main content


### PR DESCRIPTION
https://search.google.com/search-console/welcome
Need to add meta in header to let google knows this website.
.
https://github.com/jekyll/jekyll/issues/3514
And follow this way to add `<meta name="google-site-verification" content="nhKskbQxAPbq7OADIwe5KmhVGs5liv0pfe2hHTQTfFU" />` in header.

what's add in this pr : 
- update readme.md 
- add google site verification in config.