### PR TITLE
Update gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Upgrade ubuntu version.
![image](https://github.com/andy840119/andy840119.github.io/assets/9100368/d75f88bb-bc3e-41e0-ba34-fa74250cd85c)

Github is waiting for the runner, i guess the reason is there's no worker for the ubuntu-18.04.